### PR TITLE
Make procedural auto handle exceptions better

### DIFF
--- a/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoEndException.java
+++ b/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoEndException.java
@@ -1,0 +1,9 @@
+package org.redalert1741.robotbase.auto.core;
+
+public class MissingAutoEndException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    
+    public MissingAutoEndException(String type, int movenum) {
+        super("Missing AutoMoveEndFactory for type \""+type+"\" in move "+movenum);
+    }
+}

--- a/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoMoveException.java
+++ b/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoMoveException.java
@@ -1,0 +1,9 @@
+package org.redalert1741.robotbase.auto.core;
+
+public class MissingAutoMoveException extends RuntimeException {
+    private static final long serialVersionUID = 1L;
+    
+    public MissingAutoMoveException(String type, int movenum) {
+        super("Missing AutoMoveMoveFactory for type \""+type+"\" in move "+movenum);
+    }
+}

--- a/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoMoveFactoryException.java
+++ b/src/main/java/org/redalert1741/robotbase/auto/core/MissingAutoMoveFactoryException.java
@@ -1,0 +1,18 @@
+package org.redalert1741.robotbase.auto.core;
+
+public class MissingAutoMoveFactoryException extends Exception {
+    private static final long serialVersionUID = 1L;
+    
+    public enum FactoryType {
+        MOVE, END
+    }
+    
+    public FactoryType factory;
+    public String type;
+    
+    public MissingAutoMoveFactoryException(FactoryType factory, String type) {
+        super("Missing " + factory.toString() + " factory for \"" + type + "\"");
+        this.factory = factory;
+        this.type = type;
+    }
+}

--- a/src/test/resources/org/redalert1741/robotbase/auto/sync-test.json
+++ b/src/test/resources/org/redalert1741/robotbase/auto/sync-test.json
@@ -1,6 +1,6 @@
 {
     "auto": [
         {"type":"counter","args":{},"end":{"type":"manual","args":{}},"moveargs":{}},
-        {"type":"counter","args":{},"end":{"type":"manual","args":{}},"moveargs":{}}
+        {"type":"counter","args":{},"end":{"type":"manual","args":{}},"moveargs":{}},
     ]
 }


### PR DESCRIPTION
## Problem

it threw garbage exceptions whenever things were missing or there were trailing commas

## Solution

make better exceptions
eat extra commas

## Testing Notes

tests wip
